### PR TITLE
Skip dev cert generation in CI builds

### DIFF
--- a/teamorange.client/vite.config.js
+++ b/teamorange.client/vite.config.js
@@ -7,51 +7,68 @@ import path from 'path';
 import child_process from 'child_process';
 import { env } from 'process';
 
-const baseFolder =
-    env.APPDATA !== undefined && env.APPDATA !== ''
-        ? `${env.APPDATA}/ASP.NET/https`
-        : `${env.HOME}/.aspnet/https`;
+let server;
 
-const certificateName = "teamorange.client";
-const certFilePath = path.join(baseFolder, `${certificateName}.pem`);
-const keyFilePath = path.join(baseFolder, `${certificateName}.key`);
+if (!process.env.CI) {
+    const baseFolder =
+        env.APPDATA !== undefined && env.APPDATA !== ''
+            ? `${env.APPDATA}/ASP.NET/https`
+            : `${env.HOME}/.aspnet/https`;
 
-if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
-    if (0 !== child_process.spawnSync('dotnet', [
-        'dev-certs',
-        'https',
-        '--export-path',
-        certFilePath,
-        '--format',
-        'Pem',
-        '--no-password',
-    ], { stdio: 'inherit', }).status) {
-        throw new Error("Could not create certificate.");
+    const certificateName = 'teamorange.client';
+    const certFilePath = path.join(baseFolder, `${certificateName}.pem`);
+    const keyFilePath = path.join(baseFolder, `${certificateName}.key`);
+
+    if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
+        if (
+            0 !==
+            child_process.spawnSync(
+                'dotnet',
+                [
+                    'dev-certs',
+                    'https',
+                    '--export-path',
+                    certFilePath,
+                    '--format',
+                    'Pem',
+                    '--no-password',
+                ],
+                { stdio: 'inherit' },
+            ).status
+        ) {
+            throw new Error('Could not create certificate.');
+        }
     }
-}
 
-const target = env.ASPNETCORE_HTTPS_PORT ? `https://localhost:${env.ASPNETCORE_HTTPS_PORT}` :
-    env.ASPNETCORE_URLS ? env.ASPNETCORE_URLS.split(';')[0] : 'https://localhost:7140';
+    const target = env.ASPNETCORE_HTTPS_PORT
+        ? `https://localhost:${env.ASPNETCORE_HTTPS_PORT}`
+        : env.ASPNETCORE_URLS
+            ? env.ASPNETCORE_URLS.split(';')[0]
+            : 'https://localhost:7140';
+
+    server = {
+        proxy: {
+            '^/weatherforecast': {
+                target,
+                secure: false,
+            },
+        },
+        port: 5173,
+        https: {
+            key: fs.readFileSync(keyFilePath),
+            cert: fs.readFileSync(certFilePath),
+        },
+    };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [plugin()],
     resolve: {
         alias: {
-            '@': fileURLToPath(new URL('./src', import.meta.url))
-        }
-    },
-    server: {
-        proxy: {
-            '^/weatherforecast': {
-                target,
-                secure: false
-            }
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
         },
-        port: 5173,
-        https: {
-            key: fs.readFileSync(keyFilePath),
-            cert: fs.readFileSync(certFilePath),
-        }
-    }
-})
+    },
+    server,
+});
+


### PR DESCRIPTION
## Summary
- avoid generating ASP.NET dev certificates when CI environment variable is set
- prevent Vite config from blocking GitHub Actions builds

## Testing
- `CI=true npm --prefix teamorange.client run lint` *(fails: Cannot find package '@eslint/js')*
- `CI=true npm --prefix teamorange.client ci` *(fails: Unsupported platform for @rollup/rollup-win32-x64-msvc)*
- `CI=true npm --prefix teamorange.client run build` *(fails: vite not found)*
- `CI=true dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb3f41ec832395a3da398f65985c